### PR TITLE
🐠 Use absolute fish path in VS Code

### DIFF
--- a/.vscode/settings - insiders.json
+++ b/.vscode/settings - insiders.json
@@ -295,7 +295,7 @@
   "terminal.integrated.initialHint": false,
   "terminal.integrated.profiles.osx": {
     "fish (login)": {
-      "path": "fish",
+      "path": "/opt/homebrew/bin/fish",
       "args": [
         "-l"
       ],

--- a/.vscode/settings - stable.json
+++ b/.vscode/settings - stable.json
@@ -294,7 +294,7 @@
   "terminal.integrated.initialHint": false,
   "terminal.integrated.profiles.osx": {
     "fish (login)": {
-      "path": "fish",
+      "path": "/opt/homebrew/bin/fish",
       "args": [
         "-l"
       ],


### PR DESCRIPTION
Points the VS Code fish terminal profile at an absolute path.

Third in the stack — builds on #50.

## Why

#49 set `defaultProfile.osx` to `fish (login)` in both stable and insiders, but the profile itself used a bare `"path": "fish"`. That relies on VS Code inheriting a PATH that already contains Homebrew's `bin`, which is not guaranteed — GUI applications on macOS do not always inherit the login shell's PATH, so the terminal can fail to open with no obvious cause.

The sibling `pwsh` profile already used an absolute path, so this is also a consistency fix.

## What changed

Both `.vscode/settings - stable.json` and `.vscode/settings - insiders.json` now point at `/opt/homebrew/bin/fish`.

## Notes for reviewers

The path is Apple Silicon-specific. On an Intel Mac, Homebrew installs to `/usr/local`, so this would need `/usr/local/bin/fish` — worth knowing if this repo is ever set up on Intel hardware.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
