### PR TITLE
🚀 Add STRTA automation scripts

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -66,7 +66,11 @@ This is a **modular dotfiles system** with three key architectural components:
 │   ├── gh/config.yml               # GitHub CLI config
 │   └── rubocop/config.yml          # RuboCop config
 │
-├── script/                         # Executable automation (fish scripts)
+├── script/                         # STRTA entry points and automation
+│   ├── bootstrap                   # Base dependency bootstrap (POSIX shell)
+│   ├── setup                       # Idempotent links and machine setup (Bash)
+│   ├── update                      # Package and plugin updates (fish)
+│   ├── test                        # Formatting, syntax, and Brewfile checks (fish)
 │   ├── duti                        # MacOS default app handler
 │   └── brew/                       # Homebrew management
 │       ├── install                 # Smart installer script
@@ -105,7 +109,8 @@ This is a **modular dotfiles system** with three key architectural components:
 - `.vscode/` - VS Code workspace settings (stable, insiders, shared keybindings, snippets, extensions)
 - `config/fish/` - Primary shell configuration: conf.d startup files, autoloaded functions, Fisher plugin manifest
 - `config/` - Other application-specific configurations (document conversion, CLI tools, linters)
-- `script/` - Executable automation (brew management, MacOS defaults, duti) — now fish scripts
+- `script/` - STRTA entry points and machine automation
+- `script/` - STRTA entry points plus brew management and MacOS defaults
 
 **Configuration Files:**
 
@@ -122,15 +127,16 @@ This is a **modular dotfiles system** with three key architectural components:
 
 ### Machine Detection & Setup
 
-The `script/brew/install` script auto-detects machine context:
+The `script/brew/install` script auto-detects machine context through 1Password
+CLI, with `WORK_MACHINE_NAME` and `PERSONAL_MACHINE_NAME` environment variables
+available as a fallback:
 
-```bash
-# Uses hostname to determine context
-WORK_MACHINE_NAME="0x73746f65"
-PERSONAL_MACHINE_NAME="6x73746f65"
+```fish
+set -l WORK_MACHINE_NAME (op read 'op://Private/brewfiles/WORK_MACHINE/name')
+set -l PERSONAL_MACHINE_NAME (op read 'op://Private/brewfiles/PERSONAL_MACHINE/name')
 ```
 
-Creates unified Brewfile from: `Brewfile` + `Brewfile.optional` + `Brewfile.{work|personal}` + `Brewfile.vsc`
+Creates unified Brewfile from: `Brewfile` + `Brewfile.optional` + `Brewfile.{work|personal}` + `Brewfile.vsc`. The STRTA entry points in `script/` orchestrate bootstrap, setup, update, and validation.
 
 ### Integration Points
 

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,11 +7,11 @@ updates:
     groups:
       actions:
         patterns:
-          - "*"
+          - '*'
     commit-message:
       prefix: ⬆️ action
     labels:
-      - "github-action :robot:"
+      - 'github-action :robot:'
   - package-ecosystem: npm
     directory: /
     schedule:
@@ -25,5 +25,5 @@ updates:
       prefix: ⬆️ npm
       include: scope
     labels:
-      - "dependency :robot:"
+      - 'dependency :robot:'
       - javascript

--- a/readme.md
+++ b/readme.md
@@ -32,42 +32,15 @@ This collection includes configurations for:
    npm install
    ```
 
-3. **Run the brew setup** (this will install packages based on your machine):
+3. **Run the dotfiles setup** (this installs dependencies and configures links):
 
    ```bash
-   cd script/brew && ./install
+   script/setup
    ```
 
    > [!NOTE]
-   > You might want to review the [`cleanup`](./script/brew/cleanup) and [`install`](./script/brew/install) scripts to ensure it matches your machine names and needs.
-
-4. **Symlink your fish config** — `~/.config` should be a symlink to `$DFH/config` so `config/fish/` becomes your live `~/.config/fish/`:
-
-   ```bash
-   ln -s "$DFH/config" ~/.config
-   ```
-
-5. **Bootstrap [Fisher](https://github.com/jorgebucaran/fisher)** and install the pinned plugins (`PatrickF1/fzf.fish`, `IlanCosman/tide`):
-
-   ```fish
-   curl -sL https://raw.githubusercontent.com/jorgebucaran/fisher/main/functions/fisher.fish | source
-   fisher install jorgebucaran/fisher
-   fisher update
-   ```
-
-6. **Make fish your default shell:**
-
-   ```bash
-   # Homebrew's fish isn't in /etc/shells by default — add it once, then chsh.
-   echo /opt/homebrew/bin/fish | sudo tee -a /etc/shells
-   chsh -s "$(command -v fish)"
-   ```
-
-7. **Symlink what you need** (be careful, this might overwrite existing configs):
-   ```bash
-   # Copy/symlink individual files as needed
-   # No automated symlinking because that's how you accidentally nuke your existing setup
-   ```
+   > Review [`script/setup`](./script/setup) before running it. It refuses to replace a real `~/.config` directory.
+   > Use `script/setup --dry-run` to preview links without changing your home directory.
 
 ## customization
 
@@ -106,6 +79,7 @@ The beauty of dotfiles is making them your own. Local/private overrides live out
   Symlink this to `~/Documents/.dotfiles/.config.personal.local.fish`. Add any abbreviations, exports, or functions you want to keep private or specific to this machine. Sourced automatically (if present) by `config/fish/conf.d/90-local.fish`.
 
 - **`script/brew/Brewfile.*`** for package management by context
+- **`script/brew/cleanup`** for removing packages not listed in the active Brewfiles
 
 > [!IMPORTANT]
 > None of the `$DFH/.gitconfig.*.local`, `$DFH/.config.personal.local.fish` files are tracked by git — they're gitignored symlinks pointing outside the repo. Create the symlinks yourself, e.g.:

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+#/ DESCRIPTION:
+#/   Install the base dependencies required by this dotfiles repository.
+#/
+#/ USAGE:
+#/   script/bootstrap [--help]
+#/
+#/ OPTIONS:
+#/   --help    Show this help message
+
+ROOT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd -P)"
+cd "$ROOT_DIR"
+
+if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
+    grep '^#/' <"$0" | cut -c 4-
+    exit 0
+fi
+
+if [[ "$#" -gt 0 ]]; then
+    printf 'Unknown option: %s\n' "$1" >&2
+    exit 2
+fi
+
+if [[ "$(uname -s)" != "Darwin" ]]; then
+    printf 'Error: this repository supports macOS only.\n' >&2
+    exit 1
+fi
+
+if ! xcode-select -p >/dev/null 2>&1; then
+    printf 'Error: Xcode Command Line Tools are required.\n' >&2
+    printf 'Run: xcode-select --install, then rerun script/bootstrap.\n' >&2
+    exit 1
+fi
+
+if ! command -v brew >/dev/null 2>&1; then
+    printf '==> Installing Homebrew…\n'
+    NONINTERACTIVE=1 /bin/bash -c \
+        "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+fi
+
+if [[ -x /opt/homebrew/bin/brew ]]; then
+    eval "$(/opt/homebrew/bin/brew shellenv)"
+elif [[ -x /usr/local/bin/brew ]]; then
+    eval "$(/usr/local/bin/brew shellenv)"
+else
+    printf 'Error: Homebrew was not found after installation.\n' >&2
+    exit 1
+fi
+
+printf '==> Installing base Homebrew dependencies…\n'
+brew bundle --file="$ROOT_DIR/script/brew/Brewfile"
+
+if command -v npm >/dev/null 2>&1 && [[ -f package.json ]]; then
+    printf '==> Installing npm dependencies…\n'
+    npm install
+fi
+
+if command -v git >/dev/null 2>&1 && [[ -f .gitmodules ]]; then
+    printf '==> Initializing submodules…\n'
+    if ! git -c url."https://github.com/".insteadOf="git@github.com:" \
+        submodule update --init --recursive; then
+        printf 'Warning: submodules were skipped; configure GitHub authentication and rerun.\n' >&2
+    fi
+fi
+
+if command -v fish >/dev/null 2>&1; then
+    printf '==> Installing Fisher…\n'
+    fish -c '
+        if not functions -q fisher
+            curl -sL https://raw.githubusercontent.com/jorgebucaran/fisher/main/functions/fisher.fish | source
+            fisher install jorgebucaran/fisher
+        end
+    '
+fi
+
+if command -v fish >/dev/null 2>&1 &&
+    fish -c 'command -sq op; and op whoami >/dev/null 2>&1'
+then
+    printf '==> Installing machine-specific Homebrew dependencies…\n'
+    fish "$ROOT_DIR/script/brew/install"
+else
+    printf 'Warning: machine-specific Homebrew dependencies were skipped.\n' >&2
+    printf 'After configuring 1Password CLI, rerun script/brew/install.\n' >&2
+fi

--- a/script/brew/cleanup
+++ b/script/brew/cleanup
@@ -34,9 +34,14 @@ function append_cleanup_ignored_apps
     end
 end
 
-# Machine hostnames (change these to match your machines)
-set -l WORK_MACHINE_NAME (op read 'op://Private/brewfiles/WORK_MACHINE/name')
-set -l PERSONAL_MACHINE_NAME (op read 'op://Private/brewfiles/PERSONAL_MACHINE/name')
+# Machine hostnames come from 1Password when available. Environment variables
+# can provide them after bootstrap, without requiring desktop integration.
+set -l WORK_MACHINE_NAME "$WORK_MACHINE_NAME"
+set -l PERSONAL_MACHINE_NAME "$PERSONAL_MACHINE_NAME"
+if command -sq op; and op whoami >/dev/null 2>&1
+    set WORK_MACHINE_NAME (op read 'op://Private/brewfiles/WORK_MACHINE/name')
+    set PERSONAL_MACHINE_NAME (op read 'op://Private/brewfiles/PERSONAL_MACHINE/name')
+end
 set -l BREWFILE_LOCAL Brewfile.local
 
 function _cleanup_brewfile --on-event fish_exit

--- a/script/brew/install
+++ b/script/brew/install
@@ -37,9 +37,14 @@ function sync_vscode_extensions
     end
 end
 
-# Machine hostnames (change these to match your machines)
-set -l WORK_MACHINE_NAME (op read 'op://Private/brewfiles/WORK_MACHINE/name')
-set -l PERSONAL_MACHINE_NAME (op read 'op://Private/brewfiles/PERSONAL_MACHINE/name')
+# Machine hostnames come from 1Password when available. Environment variables
+# can provide them after bootstrap, without requiring desktop integration.
+set -l WORK_MACHINE_NAME "$WORK_MACHINE_NAME"
+set -l PERSONAL_MACHINE_NAME "$PERSONAL_MACHINE_NAME"
+if command -sq op; and op whoami >/dev/null 2>&1
+    set WORK_MACHINE_NAME (op read 'op://Private/brewfiles/WORK_MACHINE/name')
+    set PERSONAL_MACHINE_NAME (op read 'op://Private/brewfiles/PERSONAL_MACHINE/name')
+end
 set -l BREWFILE_LOCAL Brewfile.local
 
 # Cleanup on exit to remove temporary Brewfile.local

--- a/script/setup
+++ b/script/setup
@@ -1,0 +1,173 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+#/ DESCRIPTION:
+#/   Set up dotfiles, shell defaults, and application links.
+#/
+#/ USAGE:
+#/   script/setup [--dry-run] [--skip-bootstrap] [--skip-duti] [--help]
+#/
+#/ OPTIONS:
+#/   --dry-run          Show changes without modifying the home directory
+#/   --skip-bootstrap   Skip dependency installation
+#/   --skip-duti        Skip macOS default application setup
+#/   --help             Show this help message
+
+ROOT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd -P)"
+DRY_RUN=false
+SKIP_BOOTSTRAP=false
+SKIP_DUTI=false
+
+while [[ "$#" -gt 0 ]]; do
+    case "$1" in
+        --dry-run) DRY_RUN=true ;;
+        --skip-bootstrap) SKIP_BOOTSTRAP=true ;;
+        --skip-duti) SKIP_DUTI=true ;;
+        --help|-h)
+            grep '^#/' <"$0" | cut -c 4-
+            exit 0
+            ;;
+        *)
+            printf 'Unknown option: %s\n' "$1" >&2
+            exit 2
+            ;;
+    esac
+    shift
+done
+
+cd "$ROOT_DIR"
+
+if [[ "$DRY_RUN" == false && "$SKIP_BOOTSTRAP" == false ]]; then
+    script/bootstrap
+fi
+
+link_file() {
+    local source="$1"
+    local destination="$2"
+    local backup
+
+    if [[ ! -e "$source" && ! -L "$source" ]]; then
+        printf 'Warning: source does not exist, skipping: %s\n' "$source" >&2
+        return 0
+    fi
+
+    if [[ -L "$destination" ]]; then
+        if [[ "$(readlink "$destination")" == "$source" ]] ||
+            {
+                [[ -e "$destination" && -e "$source" ]] &&
+                    [[ "$(realpath "$destination")" == "$(realpath "$source")" ]];
+            }
+        then
+            printf '    ok       %s\n' "$destination"
+            return 0
+        fi
+        backup="${destination}.backup.$(date +%s)"
+        if [[ "$DRY_RUN" == true ]]; then
+            printf '    would relink %s\n' "$destination"
+            return 0
+        fi
+        mv -- "$destination" "$backup"
+    elif [[ -e "$destination" ]]; then
+        backup="${destination}.backup.$(date +%s)"
+        if [[ "$DRY_RUN" == true ]]; then
+            printf '    would backup and link %s\n' "$destination"
+            return 0
+        fi
+        mv -- "$destination" "$backup"
+    elif [[ "$DRY_RUN" == true ]]; then
+        printf '    would link  %s -> %s\n' "$destination" "$source"
+        return 0
+    fi
+
+    if [[ "$DRY_RUN" == false ]]; then
+        mkdir -p -- "$(dirname -- "$destination")"
+        ln -sfn -- "$source" "$destination"
+        printf '    linked   %s -> %s\n' "$destination" "$source"
+    fi
+}
+
+printf '==> Linking fish configuration…\n'
+if [[ -d "$HOME/.config" && ! -L "$HOME/.config" ]]; then
+    printf 'Error: refusing to replace real directory %s.\n' "$HOME/.config" >&2
+    printf 'Link %s manually after preserving its existing contents.\n' "$HOME/.config" >&2
+    exit 1
+fi
+link_file "$ROOT_DIR/config" "$HOME/.config"
+
+printf '==> Linking local overrides…\n'
+for file in .gitconfig.personal.local .gitconfig.github.local \
+    .gitconfig.ghedr.local .gitconfig.msft.local .config.personal.local.fish; do
+    source="$HOME/Documents/.dotfiles/$file"
+    [[ -e "$source" || -L "$source" ]] && link_file "$source" "$ROOT_DIR/$file"
+done
+
+printf '==> Linking default Git identity…\n'
+default_identity=""
+work_machine="${WORK_MACHINE_NAME:-}"
+personal_machine="${PERSONAL_MACHINE_NAME:-}"
+
+if command -v op >/dev/null 2>&1 && op whoami >/dev/null 2>&1; then
+    work_machine="$(op read 'op://Private/brewfiles/WORK_MACHINE/name' 2>/dev/null || true)"
+    personal_machine="$(op read 'op://Private/brewfiles/PERSONAL_MACHINE/name' 2>/dev/null || true)"
+fi
+
+case "$(hostname)" in
+    "${work_machine:-__unset_work__}") default_identity=.gitconfig.github.local ;;
+    "${personal_machine:-__unset_personal__}") default_identity=.gitconfig.personal.local ;;
+esac
+
+if [[ -n "$default_identity" ]]; then
+    link_file "$HOME/Documents/.dotfiles/$default_identity" \
+        "$ROOT_DIR/.gitconfig.local"
+elif [[ -L "$ROOT_DIR/.gitconfig.local" || -e "$ROOT_DIR/.gitconfig.local" ]]; then
+    printf '    keeping existing %s\n' "$ROOT_DIR/.gitconfig.local"
+else
+    printf 'Warning: could not determine machine type.\n' >&2
+    printf 'Link the default Git identity manually, for example:\n' >&2
+    printf '    ln -sfn ~/Documents/.dotfiles/.gitconfig.personal.local \\\n' >&2
+    printf '      %s/.gitconfig.local\n' "$ROOT_DIR" >&2
+fi
+
+printf '==> Linking VS Code settings…\n'
+link_file "$ROOT_DIR/.vscode/settings - stable.json" \
+    "$HOME/Library/Application Support/Code/User/settings.json"
+link_file "$ROOT_DIR/.vscode/settings - insiders.json" \
+    "$HOME/Library/Application Support/Code - Insiders/User/settings.json"
+for variant in Code "Code - Insiders"; do
+    link_file "$ROOT_DIR/.vscode/keybindings.json" \
+        "$HOME/Library/Application Support/$variant/User/keybindings.json"
+done
+
+if [[ "$DRY_RUN" == false && -n "$(command -v fish 2>/dev/null || true)" ]] &&
+    fish -c 'functions -q fisher'
+then
+    fish -c 'fisher update' || {
+        printf 'Error: Fisher plugin update failed.\n' >&2
+        exit 1
+    }
+fi
+
+if [[ "$DRY_RUN" == false && "$SKIP_DUTI" == false &&
+    -t 0 && -x "$ROOT_DIR/script/duti" ]]; then
+    printf '==> Configuring default applications…\n'
+    "$ROOT_DIR/script/duti"
+fi
+
+fish_path="$(command -v fish 2>/dev/null || true)"
+if [[ -n "$fish_path" ]]; then
+    printf '==> Configuring fish as the default shell…\n'
+    if ! grep -Fxq "$fish_path" /etc/shells; then
+        if [[ "$DRY_RUN" == true ]]; then
+            printf '    would add %s to /etc/shells\n' "$fish_path"
+        else
+            printf '%s\n' "$fish_path" | sudo tee -a /etc/shells >/dev/null
+        fi
+    fi
+    if [[ "$SHELL" != "$fish_path" ]]; then
+        if [[ "$DRY_RUN" == true ]]; then
+            printf '    would set login shell to %s\n' "$fish_path"
+        else
+            chsh -s "$fish_path"
+        fi
+    fi
+fi

--- a/script/test
+++ b/script/test
@@ -1,0 +1,43 @@
+#!/usr/bin/env fish
+
+#/ DESCRIPTION:
+#/   Validate formatting, fish syntax, Brewfiles, and POSIX scripts.
+#/
+#/ USAGE:
+#/   script/test
+
+cd (dirname (status current-filename))/..; or exit 1
+
+set -l failed 0
+
+section "PRETTIER" "formatting"
+npx prettier --check .; or set failed 1
+
+section "FISH" "syntax"
+for file in (find config/fish script -type f -name '*.fish')
+    fish -n "$file"; or set failed 1
+end
+
+section "FISH" "script formatting"
+for file in (find script -type f -name '*.fish')
+    fish_indent --check "$file"; or set failed 1
+end
+
+section "BREW" "Brewfile parsing"
+for brewfile in script/brew/Brewfile script/brew/Brewfile.optional \
+    script/brew/Brewfile.personal script/brew/Brewfile.work script/brew/Brewfile.vsc
+    brew bundle list --all --file="$brewfile" >/dev/null; or set failed 1
+end
+
+if command -sq shellcheck
+    section "SHELLCHECK" "POSIX scripts"
+    shellcheck -S warning .husky/pre-commit .husky/pre-push \
+        script/bootstrap script/setup; or set failed 1
+end
+
+if test $failed -ne 0
+    abort "tests failed"
+    exit 1
+end
+
+ok "ALL TESTS PASSED"

--- a/script/update
+++ b/script/update
@@ -1,0 +1,54 @@
+#!/usr/bin/env fish
+
+#/ DESCRIPTION:
+#/   Update packages, plugins, dependencies, and submodules.
+#/
+#/ USAGE:
+#/   script/update
+
+cd (dirname (status current-filename))/..; or exit 1
+
+if test "$argv[1]" = --help; or test "$argv[1]" = -h
+    grep '^#/' (status current-filename) | cut -c 4-
+    exit 0
+end
+
+if test (count $argv) -gt 0
+    printf 'Unknown option: %s\n' "$argv[1]" >&2
+    exit 2
+end
+
+section "UPDATE" "dependencies"
+
+if command -sq git
+    git submodule update --init --recursive; or abort "submodule update failed"; or exit 1
+end
+
+if command -sq npm; and test -f package.json
+    npm install && npm audit fix; or abort "npm install && npm audit fix failed"; or exit 1
+end
+
+if functions -q fisher
+    fisher update; or abort "fisher update failed"; or exit 1
+end
+
+if command -sq brew
+    brewup -y; or abort "brewup failed"; or exit 1
+end
+
+if command -sq npm
+    npmup -y; or abort "npmup failed"; or exit 1
+end
+
+if command -sq gh
+    ghup; or abort "ghup failed"; or exit 1
+end
+
+if command -sq op; and op whoami >/dev/null 2>&1
+    op signin
+    script/brew/install; or abort "machine-specific Homebrew update failed"; or exit 1
+else
+    printf '%sSkipping machine-specific Homebrew update: configure 1Password CLI first.%s\n' "$YELLOW" "$NC"
+end
+
+ok "UP TO DATE"


### PR DESCRIPTION
Adds the [Scripts to Rule Them All](https://github.com/github/scripts-to-rule-them-all) entry points, so setting up or maintaining this machine is a documented command rather than a sequence remembered from the readme.

Final PR in the stack — builds on #52, which created `script/`.

## Why

Setup was previously a manual checklist: install Homebrew, run the brew installer, symlink `~/.config`, bootstrap Fisher, add fish to `/etc/shells`, `chsh`. Every step had to be done in the right order, and nothing verified the result. STRTA gives each of those a normalized name that works the same way in every repository that follows the convention.

## What changed

| Script | Purpose |
| --- | --- |
| `script/bootstrap` | Installs base dependencies — Xcode CLI tools, Homebrew, base Brewfile |
| `script/setup` | Idempotent symlinks, local overrides, VS Code settings, Fisher, default shell, duti |
| `script/update` | Updates Homebrew, npm globals, Fisher, submodules, `gh` extensions |
| `script/test` | Prettier, fish syntax, fish formatting, Brewfile parsing |

**`script/setup` is designed to be safe to rerun.** It supports `--dry-run`, `--skip-bootstrap`, and `--skip-duti`; backs up conflicting files rather than overwriting them; and refuses to replace `~/.config` if it is a real directory instead of a symlink.

**Machine-aware default Git identity.** `setup` links `$DFH/.gitconfig.local` to the identity matching this machine, reusing the hostname detection already used by `script/brew/install`: 1Password when `op` is authenticated, `WORK_MACHINE_NAME`/`PERSONAL_MACHINE_NAME` environment variables otherwise. When neither resolves, it prints the exact `ln -sfn` command to run instead of guessing.

It also links the `ghedr` and `msft` overrides, so every `[include]`/`[includeIf]` in `.gitconfig` has a target after a fresh setup — previously two of them did not, which silently produced a fallback identity.

**Graceful 1Password fallback.** `bootstrap` installs the base Brewfile first and only then attempts machine-specific packages. If `op whoami` fails, it warns and skips rather than aborting, so a machine without 1Password configured can still be bootstrapped.

## Notes for reviewers

`bootstrap` and `setup` are Bash, because they run before fish is guaranteed to exist. `update` and `test` are fish, since by then it does. This means the 1Password lookup exists in both languages — `setup` mirrors the logic in `script/brew/install` rather than sharing it, which is the trade-off for not requiring fish during bootstrap.

## Validation

- `script/test` passes: Prettier, fish syntax, fish formatting, Brewfile parsing
- `script/setup --dry-run` verified on all three detection paths — personal hostname, work hostname, and the manual fallback
- All five `.gitconfig` contexts resolve to the correct identity with a signing key present

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
